### PR TITLE
action: Set the DNM labels if there are added projects

### DIFF
--- a/action.py
+++ b/action.py
@@ -345,7 +345,7 @@ def main():
             gh_pr.add_to_labels(f'{label_prefix}{p[0]}')
 
     if dnm_labels:
-        if not len(pr_projs):
+        if not len(aprojs) and not len(pr_projs):
             # Remove the DNM labels
             try:
                 for l in dnm_labels:


### PR DESCRIPTION
Whenever a project is added the PR should be DNM by default, to avoid
new projects being added to the manifest without an admin overriding the
DNM label. This is to ensure that new projects are never mistakenly
added without proper due diligence.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>