### PR TITLE
action: match revisions with a refs/ prefix

### DIFF
--- a/action.py
+++ b/action.py
@@ -321,7 +321,7 @@ def main():
         sys.exit(0)
 
     # Extract those that point to a PR
-    re_rev = re.compile(r'pull/(\d+)/head')
+    re_rev = re.compile(r'(?:refs/)?pull/(\d+)/head')
     # Revision cannot be a PR in a removed project
     pr_projs = set(filter(lambda p: re_rev.match(p[1]), uprojs | aprojs))
     log(f'PR projects: {pr_projs}')


### PR DESCRIPTION
Make sure that the DNM tag triggers with both "pull/.../head" and "refs/pull/.../head" format.

```
>>> print(re.compile(r'(refs/|)pull/(\d+)/head').match("pull/123/head"))
<re.Match object; span=(0, 13), match='pull/123/head'>
>>> print(re.compile(r'(refs/|)pull/(\d+)/head').match("refs/pull/123/head"))
<re.Match object; span=(0, 18), match='refs/pull/123/head'>
>>> print(re.compile(r'(refs/|)pull/(\d+)/head').match("123"))
None
```

Signed-off-by: Fabio Baltieri <fabiobaltieri@google.com>