### PR TITLE
action: Do not crash if repo does not match the github url

### DIFF
--- a/action.py
+++ b/action.py
@@ -377,7 +377,8 @@ def main():
                             '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/?')
         try:
             repo = gh.get_repo(re_url.match(url)[1])
-        except GithubException:
+        except (GithubException, TypeError) as error:
+            print(error)
             print(f"Can't get repo for {p[0]}; output will be limited")
             strs.append(f'| {p[0]} | {old_rev} | {new_rev} | N/A |')
             continue


### PR DESCRIPTION
If a manifest project repo is not matching the regular expression (for example because it is not in github) currently the script will crash with a TypeError exception It should not.