### PR TITLE
manifest: Add support for manifest comparison using tree checkouts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'The path to the checked out Pull Request'
     default: 'none'
     required: false
+  use-tree-checkout:
+    description: 'If true, comparison will be made on Git tree checkouts'
+    default: 'false'
+    required: false
   message:
     description: 'Message to post'
     required: false
@@ -55,7 +59,7 @@ runs:
            --checkout-path "${{ inputs.checkout-path}}" -m "${{ inputs.message }}" \
            -l "${{ inputs.labels }}" --label-prefix "${{ inputs.label-prefix }}" \
            --dnm-labels "${{ inputs.dnm-labels }}" --where "${{ inputs.where }}" \
-           -v "${{ inputs.verbosity-level }}"
+           -v "${{ inputs.verbosity-level }}" --use-tree-checkout "${{ inputs.use-tree-checkout }}"
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
The current mechanism to compare manifests using manifest files directly downloaded from GitHub works well when the main manifest does not import any other local manifest. But when the self: section of the manifest imports additional local manifests then a full tree checkout is required for West to fully resolve the manifest.

Add a new use-tree-checkout parameter that forces the script to explicitly check out a revision of the manifest repository to construct the Manifest object in order to support this use case.