### PR TITLE
action.py: Always execute all the logic

### DIFF
--- a/action.py
+++ b/action.py
@@ -321,7 +321,7 @@ def main():
             break
 
     if not new_mfile:
-        log('Manifest file {args.path} not modified by this Pull Request')
+        log(f'Manifest file {args.path} not modified by this Pull Request')
         sys.exit(0)
 
     base_sha = get_merge_base(gh_pr, checkout)


### PR DESCRIPTION
    Until now the script was dropping out early whenever the manifest file
    had not changed in the Pull Request. This however did not play well in
    two different scenarios:

    - When using a checked out tree, the modified file could be an included
      manifest, and not the main one. In that case the checks needed
      executing all the same
    - When updating the Pull Request to a version of it that no longer
      modifies the manifest, the labels and comments require updating to
      reflect the fact that the manifest is not modified anymore

    Fix both issues by always executing all the logic, and conditionally
    affecting the Pull Request based on whether there were any changes to
    the projects at all.

    Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
