### PR TITLE
action: Add a new option to check for impostor commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'If true, comparison will be made on Git tree checkouts'
     default: 'false'
     required: false
+  check-impostor-commits:
+    description: 'If true, a check for impostor commits will be performed'
+    default: 'false'
+    required: false
   message:
     description: 'Message to post'
     required: false
@@ -55,7 +59,8 @@ runs:
            --checkout-path "${{ inputs.checkout-path}}" -m "${{ inputs.message }}" \
            -l "${{ inputs.labels }}" --label-prefix "${{ inputs.label-prefix }}" \
            --dnm-labels "${{ inputs.dnm-labels }}"  -v "${{ inputs.verbosity-level }}" \
-           --use-tree-checkout "${{ inputs.use-tree-checkout }}"
+           --use-tree-checkout "${{ inputs.use-tree-checkout }}" \
+           --check-impostor-commits "${{ inputs.check-impostor-commits }}"
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
On GitHub, commits can appear to be in a repo but in fact only be present in a fork. To avoid letting users point to these type of commits, named impostor commits, add an optional check that will not remove the DNM label if one is present.

More info here:
https://www.chainguard.dev/unchained/what-the-fork-imposter-commits-in-github-actions-and-ci-cd