### PR TITLE
Check additional metadata in projects

### DIFF
--- a/action.py
+++ b/action.py
@@ -259,13 +259,15 @@ def _get_manifests_from_tree(mpath, gh_pr, checkout, base_sha):
 
     return (old_manifest, new_manifest)
 
-def _get_status_note(len_a, len_pr, impostor_shas):
+def _get_status_note(len_a, len_r, len_pr, impostor_shas):
     strs = []
     def plural(count):
         return 's' if count > 1 else ''
 
     if len_a:
         strs.append(f'{len_a} added project{plural(len_a)}')
+    if len_r:
+        strs.append(f'{len_r} removed project{plural(len_r)}')
     if len_pr:
         strs.append(f'{len_pr} project{plural(len_pr)} with PR revision')
     if impostor_shas:
@@ -475,7 +477,8 @@ def main():
         strs.append(line)
 
     # Add a note about the merge status of the manifest PR
-    status_note = _get_status_note(len(aprojs), len(pr_projs), impostor_shas)
+    status_note = _get_status_note(len(aprojs), len(rprojs), len(pr_projs),
+                                   impostor_shas)
     status_note = f'\n\n{status_note}'
 
     message = '\n'.join(strs) + status_note + NOTE
@@ -535,7 +538,7 @@ def main():
                         log(f'Unable to remove prefixed label {l}')
 
     if dnm_labels:
-        if not len(aprojs) and not len(pr_projs) and not impostor_shas:
+        if not len(rprojs) and not len(aprojs) and not len(pr_projs) and not impostor_shas:
             # Remove the DNM labels
             try:
                 for l in dnm_labels:

--- a/action.py
+++ b/action.py
@@ -171,7 +171,7 @@ def fmt_rev(repo, rev):
 
     try:
         if maybe_sha(rev):
-            branches = [b.name for b in repo.get_branches() if rev ==
+            branches = [f'`{b.name}`' for b in repo.get_branches() if rev ==
                         b.commit.sha]
             s = repo.get_commit(rev).html_url
             # commits get formatted nicely by GitHub itself

--- a/action.py
+++ b/action.py
@@ -219,7 +219,7 @@ def _get_manifests_from_gh(token, gh_repo, mpath, new_mfile, base_sha):
     try:
         old_mfile = gh_repo.get_contents(mpath, base_sha)
     except GithubException:
-        print('Base revision does not contain a valid manifest')
+        log('Base revision does not contain a valid manifest')
         exit(0)
 
     old_manifest = manifest_from_url(token, old_mfile.download_url)
@@ -303,7 +303,7 @@ def main():
                         type=int, default=0, choices=range(0, 2),
                         required=False, help='Verbosity level.')
 
-    print(sys.argv)
+    log(sys.argv)
 
     args = parser.parse_args()
 
@@ -423,8 +423,8 @@ def main():
         try:
             repo = gh.get_repo(re_url.match(url)[1])
         except (GithubException, TypeError) as error:
-            print(error)
-            print(f"Can't get repo for {p[0]}; output will be limited")
+            log(error)
+            log(f"Can't get repo for {p[0]}; output will be limited")
             strs.append(f'| {p[0]} | {old_rev} | {new_rev} | N/A |')
             continue
 
@@ -458,12 +458,12 @@ def main():
 
     if not comment:
         if len(projs):
-            print('Creating comment')
+            log('Creating comment')
             comment = gh_pr.create_issue_comment(message)
         else:
-            print('Skipping comment creation, no manifest changes')
+            log('Skipping comment creation, no manifest changes')
     else:
-        print('Updating comment')
+        log('Updating comment')
         comment.edit(message)
 
     if not comment:
@@ -490,7 +490,7 @@ def main():
                     log(f'removing label {l}')
                     gh_pr.remove_from_labels(l)
                 except GithubException:
-                    print(f'Unable to remove label {l}')
+                    log(f'Unable to remove label {l}')
 
     if label_prefix:
         for p in projs:
@@ -503,7 +503,7 @@ def main():
                         log(f'removing label {l}')
                         gh_pr.remove_from_labels(l)
                     except GithubException:
-                        print(f'Unable to remove prefixed label {l}')
+                        log(f'Unable to remove prefixed label {l}')
 
     if dnm_labels:
         if not len(aprojs) and not len(pr_projs) and not impostor_sha:
@@ -513,7 +513,7 @@ def main():
                     log(f'removing label {l}')
                     gh_pr.remove_from_labels(l)
             except GithubException:
-                print('Unable to remove DNM label')
+                log('Unable to remove DNM label')
         else:
             # Add the DNM labels
             for l in dnm_labels:

--- a/action.py
+++ b/action.py
@@ -286,6 +286,28 @@ def _get_status_note(len_a, len_r, len_pr, impostor_shas):
     n += '**'
     return n
 
+def _get_sets(old_projs, new_projs):
+    # Symmetric difference: everything that is not in both
+
+    # Removed projects
+    rprojs = set(filter(lambda p: p[0] not in list(p[0] for p in new_projs),
+                        old_projs - new_projs))
+    # Updated projects
+    uprojs = set(filter(lambda p: p[0] in list(p[0] for p in old_projs),
+                        new_projs - old_projs))
+    # Added projects
+    aprojs = new_projs - old_projs - uprojs
+
+    # All projs
+    projs = rprojs | uprojs | aprojs
+
+    log(f'rprojs: {rprojs}')
+    log(f'uprojs: {uprojs}')
+    log(f'aprojs: {aprojs}')
+
+    return (projs, rprojs, uprojs, aprojs)
+
+
 def main():
 
     parser = argparse.ArgumentParser(
@@ -395,27 +417,13 @@ def main():
 
     old_projs = set((p.name, p.revision) for p in old_manifest.projects)
     new_projs = set((p.name, p.revision) for p in new_manifest.projects)
+
     log(f'old_projs: {old_projs}')
     log(f'new_projs: {new_projs}')
 
-    # Symmetric difference: everything that is not in both
+    (projs, rprojs, uprojs, aprojs) = _get_sets(old_projs, new_projs)
 
-    # Removed projects
-    rprojs = set(filter(lambda p: p[0] not in list(p[0] for p in new_projs),
-                        old_projs - new_projs))
-    # Updated projects
-    uprojs = set(filter(lambda p: p[0] in list(p[0] for p in old_projs),
-                        new_projs - old_projs))
-    # Added projects
-    aprojs = new_projs - old_projs - uprojs
-
-    # All projs
-    projs = rprojs | uprojs | aprojs
     projs_names = [name for name, rev in projs]
-
-    log(f'rprojs: {rprojs}')
-    log(f'uprojs: {uprojs}')
-    log(f'aprojs: {aprojs}')
 
     if not len(projs):
         log('No projects updated')

--- a/action.py
+++ b/action.py
@@ -460,6 +460,8 @@ def main():
         old_rev = None if p in aprojs else next(
             filter(lambda _p: _p[0] == p[0], old_projs))[1]
         new_rev = None if p in rprojs else p[1]
+        or_note = ' (Added)' if not old_rev else ''
+        nr_note = ' (Removed)' if not new_rev else ''
         url = manifest.get_projects([p[0]])[0].url
         re_url = re.compile(r'https://github\.com/'
                             '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/?')
@@ -468,21 +470,21 @@ def main():
         except (GithubException, TypeError) as error:
             log(error)
             log(f"Can't get repo for {p[0]}; output will be limited")
-            strs.append(f'| {p[0]} | {old_rev} | {new_rev} | N/A |')
+            strs.append(f'| {p[0]} | {old_rev}{or_note} | {new_rev}{nr_note} | N/A |')
             continue
 
-        line = f'| {p[0]} | {fmt_rev(repo, old_rev)} '
+        line = f'| {p[0]} | {fmt_rev(repo, old_rev)}{or_note} '
         if p in pr_projs:
             pr = repo.get_pull(int(re_rev.match(new_rev)[1]))
-            line += f'| {pr.html_url} '
+            line += f'| {pr.html_url}{nr_note} '
             line += f'| [{repo.full_name}#{pr.number}/files]' + \
                     f'({pr.html_url}/files) |'
         else:
             if check_impostor and new_rev and is_impostor(repo, new_rev):
                 impostor_shas += 1
-                line += f'|\u274c Impostor SHA: {fmt_rev(repo, new_rev)} '
+                line += f'|\u274c Impostor SHA: {fmt_rev(repo, new_rev)}{nr_note} '
             else:
-                line += f'| {fmt_rev(repo, new_rev)} '
+                line += f'| {fmt_rev(repo, new_rev)}{nr_note}'
             if p in uprojs:
                 line += f'| [{repo.full_name}@{shorten_rev(old_rev)}..' + \
                         f'{shorten_rev(new_rev)}]' + \

--- a/action.py
+++ b/action.py
@@ -462,7 +462,7 @@ def main():
             line += f'| [{repo.full_name}#{pr.number}/files]' + \
                     f'({pr.html_url}/files) |'
         else:
-            if check_impostor and is_impostor(repo, new_rev):
+            if check_impostor and new_rev and is_impostor(repo, new_rev):
                 impostor_shas += 1
                 line += f'|\u274c Impostor SHA: {fmt_rev(repo, new_rev)} '
             else:

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,11 @@ inputs:
     required: false
     default: '0'
   manifest-path:
-    description: 'The path to the manifest file'
+    description: 'The relative path to the manifest file'
     required: true
   checkout-path:
-    description: 'The path to the checked out Pull Request'
+    description: 'The path to the checked out PR. Relative or absolute depending on
+                  whether the GITHUB_WORKSPACE env var is defined'
     default: 'none'
     required: false
   use-tree-checkout:
@@ -56,6 +57,7 @@ runs:
     - id: run-python
       run: |
            python3 ${{ github.action_path }}/action.py -p "${{ inputs.manifest-path }}" \
+           --pr "${{ github.repository }}/${{ github.event.pull_request.number }}" \
            --checkout-path "${{ inputs.checkout-path}}" -m "${{ inputs.message }}" \
            -l "${{ inputs.labels }}" --label-prefix "${{ inputs.label-prefix }}" \
            --dnm-labels "${{ inputs.dnm-labels }}"  -v "${{ inputs.verbosity-level }}" \


### PR DESCRIPTION
    action: Check additional metadata in projects
    
    Until now this action was only looking at differences in revision for
    all the projects in the manifest. However, there are other items of
    metadata that can be highly sensitive, and changes to those must be
    monitored and reported.
    
    This commit introduces additional checks for the following metadata
    items:
    
    - URL: part of the manifest, URL to the project repository
    - Submodules: part of the manifest, enabled submodules when running west
      update
    - West commands: part of the manifest, pointer to a file defining
      extensions commands for west itself
    - module.yml: the Zephyr module metadata file
    
    If any of the items above is added, removed or changed, the DNM label
    will not be removed from the Pull Request, in order for a human to
    decide if the PR is to be merged or not.

Screenshot:

<img width="757" alt="image" src="https://github.com/user-attachments/assets/cb5b7435-344b-4237-ac04-2d714e1fdf99">
