### PR TITLE
[RFC] action: Allow specifying a list of allowed unreachable repos

### DIFF
--- a/action.py
+++ b/action.py
@@ -360,6 +360,10 @@ def main():
                         required=False,
                         help='Check for impostor commits.')
 
+    parser.add_argument('--allowed-unreachables', action='store',
+                        required=False,
+                        help='Comma-separated list of repos which are allowed to be unreachable.')
+
     parser.add_argument('-l', '--labels', action='store',
                         required=False,
                         help='Comma-separated list of labels.')
@@ -388,6 +392,8 @@ def main():
     import_flag = str2import_flag(args.west_import_flag or 'all')
     use_tree = args.use_tree_checkout != 'false'
     check_impostor = args.check_impostor_commits != 'false'
+    allowed_unreachables = [x.strip() for x in args.allowed_unreachables.split(',')] \
+        if args.allowed_unreachables != 'none' else None
     labels = [x.strip() for x in args.labels.split(',')] \
         if args.labels != 'none' else None
     dnm_labels = [x.strip() for x in args.dnm_labels.split(',')] \
@@ -501,7 +507,9 @@ def main():
             log(error)
             log(f"Can't get repo for {p[0]}; output will be limited")
             strs.append(f'| {p[0]}{name_note} | {old_rev}{or_note} | {new_rev}{nr_note} | N/A |')
-            unreachables += 1
+
+            if p[0] not in allowed_unreachables:
+                unreachables += 1
             continue
 
         line = f'| {p[0]}{name_note} | {fmt_rev(repo, old_rev)}{or_note} '

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,11 @@ inputs:
     description: 'Message to post'
     required: false
     default: 'none'
+  allowed-unreachables:
+    description: |
+      Comma-separated list of repos which are allowed to be unreachable
+    required: false
+    default: 'none'
   labels:
     description: |
       Comma-separated list of labels with optional module name filter:
@@ -65,6 +70,7 @@ runs:
            --pr "${{ github.repository }}/${{ github.event.pull_request.number }}" \
            --checkout-path "${{ inputs.checkout-path}}" -m "${{ inputs.message }}" \
            -l "${{ inputs.labels }}" --label-prefix "${{ inputs.label-prefix }}" \
+           --allowed-unreachables "${{ inputs.allowed-unreachables }}" \
            --dnm-labels "${{ inputs.dnm-labels }}"  -v "${{ inputs.verbosity-level }}" \
            --use-tree-checkout "${{ inputs.use-tree-checkout }}" \
            --west-import-flag "${{ inputs.west-import-flag }}" \


### PR DESCRIPTION
Sometimes a manifest file contains a repo which is not accessible from github. When such a repo revision is updated, we do not want to add a DNM label to it.