### PR TITLE
action: Handle parsing of module.yml and binary blobs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,15 @@ inputs:
     required: false
     default: 'none'
   dnm-labels:
-    description: 'Comma-separated list of labels.'
+    description: 'Comma-separated list of DNM labels.'
+    required: false
+    default: 'none'
+  blobs-added-labels:
+    description: 'Comma-separated list of blobs added labels.'
+    required: false
+    default: 'none'
+  blobs-modified-labels:
+    description: 'Comma-separated list of blobs modified labels.'
     required: false
     default: 'none'
   label-prefix:
@@ -71,7 +79,8 @@ runs:
            --checkout-path "${{ inputs.checkout-path}}" -m "${{ inputs.message }}" \
            -l "${{ inputs.labels }}" --label-prefix "${{ inputs.label-prefix }}" \
            --allowed-unreachables "${{ inputs.allowed-unreachables }}" \
-           --dnm-labels "${{ inputs.dnm-labels }}"  -v "${{ inputs.verbosity-level }}" \
+           --dnm-labels "${{ inputs.dnm-labels }}" --blobs-added-labels "${{ inputs.blobs-added-labels }}" \
+           --blobs-modified-labels "${{ inputs.blobs-modified-labels }}" -v "${{ inputs.verbosity-level }}" \
            --use-tree-checkout "${{ inputs.use-tree-checkout }}" \
            --west-import-flag "${{ inputs.west-import-flag }}" \
            --check-impostor-commits "${{ inputs.check-impostor-commits }}"


### PR DESCRIPTION
    This commit adds support for handling the differences inside the
    module.yml file in a west project update, as well as locating and
    displaying any changes to binary blobs.
    More specifically, the metadata table now displays the number of added
    and/or changed blobs per project, and optionall labels can be added to
    the Pull Request to signal reviewers that blobs have been altered.


Tested in https://github.com/zephyrproject-rtos/zephyr-testing/pull/291

<img width="791" alt="image" src="https://github.com/user-attachments/assets/8a031531-d337-4b87-bb5b-3b776704d794" />

<img width="324" alt="image" src="https://github.com/user-attachments/assets/37db378b-5486-48e6-933c-ce2fab175b2f" />
